### PR TITLE
Disable overflow of the service tabs [RHCLOUD-20715]

### DIFF
--- a/src/pages/Service.js
+++ b/src/pages/Service.js
@@ -85,6 +85,7 @@ export default function Service() {
                 onSelect={handleTabClick}
                 isBox={false}
                 aria-label="Select between commits and deploys tabs"
+                style={{overflow: "visible"}}
             >
                 <Tab key={0} eventKey={0} title={<TabTitleText>Details</TabTitleText>}>
                     <PageSection variant={PageSectionVariants.light}>


### PR DESCRIPTION
## What?
Disables the overflow of the tabs in the service page.

## Why?
The tabs disappear when the page is too small.

## How?
Forcing the overflow to be visible.

## Testing
Did you add any tests for the change?

## Anything Else?
When the page is too small for all tabs to fit, patternfly gives you some arrows to browse all the available tabs by default. However, this default behavior does not seem work for us. I looked for the cause, but I was not able to find the root of the issue. So, I decided to settle for the next best thing e.g. forcing the overflow to stay visible by default. If anyone finds the actual cause of the issue, feel free to take this out.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
