### PR TITLE
[RHCLOUD-20425] Clickable filter

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -1,3 +1,7 @@
+export const SERVICE_FILTERS = [
+    'Name', 'Display_Name', 'Tenant', 'Namespace', 'Branch'
+];
+
 export const COMMIT_FILTERS = [
     'Repo', 'Ref', 'Author', 'Merged_By'
 ];
@@ -9,8 +13,8 @@ export const DEPLOY_FILTERS = [
 export const FILTER_MAP = [
     {
         path: "/services",
-        show: false,
-        options: []
+        show: true,
+        options: SERVICE_FILTERS
     },
     {
         path: "/commits",

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -12,6 +12,12 @@ export const DEPLOY_FILTERS = [
 
 export const FILTER_MAP = [
     {
+        // dont show filters on the /services/{service} pages
+        path: "/services/*[a-zA-Z0-9]",
+        show: false,
+        options: [],
+    },
+    {
         path: "/services",
         show: true,
         options: SERVICE_FILTERS

--- a/src/components/filters/FilterManager.js
+++ b/src/components/filters/FilterManager.js
@@ -59,7 +59,11 @@ export default function FilterManager(props) {
         params.forEach((value, key) => {
             // search for the key in the options array, not case sensitive
             const option = options.find(option => option.toLowerCase() === key.toLowerCase());
-            if (option) {
+
+            // check if the key value pair is already in the filters array
+            const found = newFilters.find(filter => filter.field === option && filter.value === value);
+            
+            if (option && !found) {
                 newFilters.push({field: option, value: value});
             }
             else {
@@ -105,6 +109,33 @@ export default function FilterManager(props) {
         return filters;
     }
 
+    // function for clickable fields
+    // given the field name and the value, add the filter
+    function addFilter(field, value) {
+        // search for the key in the options array, not case sensitive
+        let newFilter = {};
+
+        let formatted = field.replace(/ /g,"_").toLowerCase();
+        const option = options.find(option => option.toLowerCase() === formatted);
+
+        // check if the key value pair is already in the filters array
+        const found = filters.find(filter => filter.field === option && filter.value === value);
+
+        if (option && !found) {
+            newFilter = {field: option, value: value};
+        } else {
+            return;
+        }
+
+        setFilters([...filters, newFilter]);
+    }
+
+    function checkOptions(field) {
+        let formatted = field.replace(/ /g,"_").toLowerCase();
+        return options.find(option => option.toLowerCase() === formatted);
+    }
+        
+
     function setDate(start, end) {
         // set the start and end dates
         setStartDate(start);
@@ -118,7 +149,7 @@ export default function FilterManager(props) {
     }
 
     return (
-        <FilterContext.Provider value={{ filters, options, startDate, endDate, setFilters, setDate, show, clear }}>
+        <FilterContext.Provider value={{ filters, options, startDate, endDate, getFilters, addFilter, checkOptions, setFilters, setDate, show, clear }}>
             { props.children }
         </FilterContext.Provider>
     )

--- a/src/components/tables/CommitTable.js
+++ b/src/components/tables/CommitTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 
 import Moment from 'react-moment';
 
@@ -6,7 +6,10 @@ import { Td } from '@patternfly/react-table';
 
 import { CodeBranchIcon } from '@patternfly/react-icons';
 
+import { FilterContext } from 'components/filters';
+
 import GenericTable from './GenericTable';
+import Hoverable from './Hoverable';
 
 import { commitsSchema } from 'schema';
 
@@ -14,6 +17,7 @@ import { commitsSchema } from 'schema';
  * Options to pass in the desired data or the data path to the table
  */
 function CommitTable({dataPath = "/api/v1/commits", noTitle=false, gh_url="", gl_url=""}) {
+    const filterContext = useContext(FilterContext);
 
     function FormatColumn(column) {
         const formatted = commitsSchema[column]
@@ -30,6 +34,8 @@ function CommitTable({dataPath = "/api/v1/commits", noTitle=false, gh_url="", gl
         }
 
         let cellContents;
+
+        let hoverable = false;
         
         if (column === "Ref") {
             // a link to the commit, so this function needs a service's url
@@ -52,6 +58,12 @@ function CommitTable({dataPath = "/api/v1/commits", noTitle=false, gh_url="", gl
             cellContents = <Moment date={cell} />;
         } else {
             cellContents = <>{cell}</>;
+            hoverable = true;
+        }
+
+        // if you can filter by the column, wrap the contents in hoverable
+        if (hoverable && filterContext.checkOptions(column)) {
+            cellContents = <Hoverable filter={column} value={cell} >{cellContents}</Hoverable>
         }
 
         return <Td key={`${rowIndex}_${cellIndex}`} 

--- a/src/components/tables/DeployTable.js
+++ b/src/components/tables/DeployTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import Moment from 'react-moment';
 
@@ -6,11 +6,16 @@ import { Td } from '@patternfly/react-table';
 
 import { CodeBranchIcon } from '@patternfly/react-icons';
 
+import { FilterContext } from 'components/filters';
+
 import GenericTable from './GenericTable';
+import Hoverable from './Hoverable';
 
 import { deploysSchema } from 'schema';
 
 function DeployTable({dataPath = "/api/v1/deploys", noTitle=false }) {
+    const filterContext = useContext(FilterContext);
+
     function FormatColumn(column) {
         const formatted = deploysSchema[column]
         return formatted === undefined ? null : formatted;
@@ -25,6 +30,7 @@ function DeployTable({dataPath = "/api/v1/deploys", noTitle=false }) {
         }
 
         let expandable = false;
+        let hoverable = false;
 
         let cellContents;
         
@@ -40,6 +46,12 @@ function DeployTable({dataPath = "/api/v1/deploys", noTitle=false }) {
             cellContents = <Moment date={cell} />;
         } else {
             cellContents = <>{cell}</>;
+            hoverable = true;
+        }
+
+        // if you can filter by the column, wrap the contents in hoverable
+        if (hoverable && filterContext.checkOptions(column)) {
+            cellContents = <Hoverable filter={column} value={cell} >{cellContents}</Hoverable>
         }
 
         return <Td key={`${rowIndex}_${cellIndex}`} 

--- a/src/components/tables/Hoverable.js
+++ b/src/components/tables/Hoverable.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState, useContext } from 'react';
+
+import { Button, Tooltip } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+import { FilterContext } from 'components/filters';
+
+export default function Hoverable(props) {
+    const filter = props.filter;
+    const value = props.value;
+
+    const filterContext = useContext(FilterContext);
+
+    const [isHovered, setHover] = useState(false);
+
+    const clickHandler = ()  => {
+        filterContext.addFilter(filter, value);
+    };
+
+    return (
+        <Tooltip content={value}>
+            <Button
+                onClick={clickHandler}
+                variant='plain'
+                onMouseOver={ () => setHover(true) }
+                onMouseOut={ () => setHover(false) }
+            >
+                {props.children}
+                {<PlusCircleIcon visibility={isHovered ? 'visible' : 'hidden'} />}
+            </Button>
+        </Tooltip>
+    );
+};

--- a/src/components/tables/ServiceTable.js
+++ b/src/components/tables/ServiceTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import {Td} from '@patternfly/react-table';
 
@@ -8,11 +8,16 @@ import { NavLink } from 'react-router-dom';
 
 import Moment from 'react-moment';
 
+import { FilterContext } from 'components/filters';
+
 import GenericTable from './GenericTable';
+import Hoverable from './Hoverable';
 
 import { expandedServicesSchema } from 'schema';
 
 function ServiceTable({dataPath = "/api/v1/services"}) {
+    const filterContext = useContext(FilterContext);
+
     function FormatColumn(column) {
         const formatted = expandedServicesSchema[column]
         return formatted === undefined ? null : formatted;
@@ -27,6 +32,10 @@ function ServiceTable({dataPath = "/api/v1/services"}) {
         }
 
         let expandable = false;
+        
+        // if the column is filterable (and not a link already),
+        // wrap the contents in a hoverable
+        let hoverable = false;
 
         let cellContents;
 
@@ -46,8 +55,6 @@ function ServiceTable({dataPath = "/api/v1/services"}) {
             cellContents = <a href={cell} target="_blank" rel="noreferrer">
                                 <GitlabIcon key="icon" />
                             </a>;
-        } else if (column === "Merged by") {
-            cellContents = <>Merged By</>;
         } else if (column === "Latest commit") {
             if (cell !== null && cell.id !== 0) {
                 cellContents = <><CodeBranchIcon /><Moment date={cell.timestamp} format=" MM/YYYY"/></>;
@@ -56,11 +63,18 @@ function ServiceTable({dataPath = "/api/v1/services"}) {
         } else if (column === "Latest deploy") {
             if (cell !== null && cell.id !== 0) {
                 cellContents = <><CodeBranchIcon /><Moment date={cell.timestamp} format=" MM/YYYY"/></>;
-                 expandable = true;
+                expandable = true;
             }
         } else {
             cellContents = <>{cell}</>;
+            hoverable = true;
         }
+        
+        // if you can filter by the column, wrap the contents in hoverable
+        if (hoverable && filterContext.checkOptions(column)) {
+            cellContents = <Hoverable filter={column} value={cell} >{cellContents}</Hoverable>
+        }
+
         return <Td key={`${rowIndex}_${cellIndex}`} 
                     dataLabel={column}
                     compoundExpand={expandable && compoundExpandParams != null ? compoundExpandParams(rowIndex, cellIndex) : null}

--- a/src/pages/Service.js
+++ b/src/pages/Service.js
@@ -129,6 +129,9 @@ export default function Service() {
                     <PageSection variant={PageSectionVariants.light}>
                         <TextContent>
                             <TextList component={TextListVariants.dl}>
+                                <TextListItem component={TextListItemVariants.dt}>Tenant</TextListItem>
+                                <TextListItem component={TextListItemVariants.dd}>{service.tenant ? service.tenant : NONE_SPECIFIED}</TextListItem>
+                            
                                 <TextListItem component={TextListItemVariants.dt}>Namespace</TextListItem>
                                 <TextListItem component={TextListItemVariants.dd}>{service.namespace ? service.namespace : NONE_SPECIFIED}</TextListItem>
 

--- a/src/schema/Services.js
+++ b/src/schema/Services.js
@@ -9,6 +9,7 @@ export const services = {
 
 export const expandedServices = {
     display_name: 'Name',
+    tenant: 'Tenant',
     gh_repo: 'Github',
     gl_repo: 'Gitlab',
     deploy_file: 'Deploy file',


### PR DESCRIPTION
## What?
[RHCLOUD-20425](https://issues.redhat.com/browse/RHCLOUD-20425)
You can click a field like in payload tracker and it adds it to the filter query.

![filters](https://user-images.githubusercontent.com/87503474/204861884-33085faa-4d2b-497d-96d3-03963513c58f.gif)

## Why?
Makes it easier to add filters.

## How?

## Testing

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
