### PR TITLE
Corrected build reference to dist folder

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ COPY .babelrc ./.babelrc
 
 RUN yarn run build && \
     rm -rfv /usr/share/nginx/html && \
-    mv /usr/src/app/build /usr/share/nginx/html && \
+    mv /usr/src/app/dist /usr/share/nginx/html && \
     chown nginx:nginx -R /usr/share/nginx/html && \
     chmod 777 -R /var/log/nginx && \
     mkdir -p /var/cache/nginx && \


### PR DESCRIPTION
Previous build was failing with: `15:01:35 mv: cannot stat '/usr/src/app/build': No such file or directory`

Changed the Containerfile to reference the dist folder like in payload tracker. https://github.com/RedHatInsights/payload-tracker-frontend/blob/master/Dockerfile#L23