### PR TITLE
Changing app root

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ podman rm platform-changelog
 When accessing the api, you may have to change the proxy address in ```ui/package.json``` from ```localhost``` to your IP.
 
 
-You can now access the application UI on `http://localhost:3000/app/platform-changelog/`. 
+You can now access the application UI on `http://localhost:3000/ui/`. 
 
 
 To reset your local database:

--- a/nginx.conf
+++ b/nginx.conf
@@ -37,7 +37,7 @@ http {
         listen 8080;
         disable_symlinks off;
         root /usr/share/nginx/html;
-        location /api/platform-changelog/v1 {
+        location /api/v1 {
              proxy_pass http://API_HOST:8000;
              #proxy_http_version 1.1;
              #proxy_set_header Upgrade $http_upgrade;

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -1,5 +1,5 @@
-export const API_URL = process.env.ENV === 'development' ? 'http://localhost:8000' : '/app/platform-changelog';
-export const APP_ROOT = '/app/platform-changelog';
+export const API_URL = process.env.ENV === 'development' ? 'http://localhost:8000' : '';
+export const APP_ROOT = '/ui';
 
 export const SERVICE_FILTERS = [
     'Name', 'Display_Name', 'Tenant', 'Namespace', 'Branch'

--- a/src/components/Timelines.js
+++ b/src/components/Timelines.js
@@ -17,7 +17,7 @@ import { TimelineCardWrapper as TimelineCard } from './TimelineCard';
 
 const PER_CALL = 10;
 
-function Timelines({dataPath=`/api/platform-changelog/v1/timelines`, includeRepo = false, ghURL="", glURL=""}) {
+function Timelines({dataPath=`/api/v1/timelines`, includeRepo = false, ghURL="", glURL=""}) {
     const [timelines, setTimelines] = useState([]);
     const [offset, setOffset] = useState(0);
     const [count, setCount] = useState(0);

--- a/src/components/tables/CommitTable.js
+++ b/src/components/tables/CommitTable.js
@@ -16,7 +16,7 @@ import { commitsSchema } from '../../schema';
 /**
  * Options to pass in the desired data or the data path to the table
  */
-function CommitTable({dataPath="/api/platform-changelog/v1/commits", includeExport=true, ghURL="", glURL=""}) {
+function CommitTable({dataPath="/api/v1/commits", includeExport=true, ghURL="", glURL=""}) {
     const filterContext = useContext(FilterContext);
 
     function FormatColumn(column) {

--- a/src/components/tables/DeployTable.js
+++ b/src/components/tables/DeployTable.js
@@ -13,7 +13,7 @@ import Hoverable from './Hoverable';
 
 import { deploysSchema } from '../../schema';
 
-function DeployTable({dataPath = "/api/platform-changelog/v1/deploys", includeExport=true }) {
+function DeployTable({dataPath = "/api/v1/deploys", includeExport=true }) {
     const filterContext = useContext(FilterContext);
 
     function FormatColumn(column) {

--- a/src/components/tables/ServiceTable.js
+++ b/src/components/tables/ServiceTable.js
@@ -15,7 +15,7 @@ import Hoverable from './Hoverable';
 
 import { expandedServicesSchema } from '../../schema';
 
-function ServiceTable({dataPath = "/api/platform-changelog/v1/services", includeExport = true}) {
+function ServiceTable({dataPath = "/api/v1/services", includeExport = true}) {
     const filterContext = useContext(FilterContext);
 
     function FormatColumn(column) {

--- a/src/pages/Service.js
+++ b/src/pages/Service.js
@@ -59,7 +59,7 @@ export default function Service() {
     const deploysTabRef = React.createRef();
 
     useEffect(() => {
-        fetchService(`${API_URL}/api/platform-changelog/v1/services/${name}`);
+        fetchService(`${API_URL}/api/v1/services/${name}`);
     }, []);
 
     async function fetchService(path) {
@@ -152,7 +152,7 @@ export default function Service() {
                         aria-label={`Timeline display for ${service.display_name}`}
                         hidden
                     >
-                        <Timelines dataPath={`/api/platform-changelog/v1/services/${name}/timelines`} ghURL={service.gh_repo} glURL={service.gl_repo} />
+                        <Timelines dataPath={`/api/v1/services/${name}/timelines`} ghURL={service.gh_repo} glURL={service.gl_repo} />
                     </TabContent>
                     <TabContent
                         eventKey={2}
@@ -161,7 +161,7 @@ export default function Service() {
                         aria-label={`Commits display for ${service.display_name}`}
                         hidden
                     >
-                        <CommitTable key={service.id} dataPath={`/api/platform-changelog/v1/services/${name}/commits`} ghURL={service.gh_repo} glURL={service.gl_repo} />
+                        <CommitTable key={service.id} dataPath={`/api/v1/services/${name}/commits`} ghURL={service.gh_repo} glURL={service.gl_repo} />
                     </TabContent>
                     <TabContent
                         eventKey={3}
@@ -170,7 +170,7 @@ export default function Service() {
                         aria-label={`Deploys display for ${service.display_name}`}
                         hidden
                     >
-                        <DeployTable key={service.name} dataPath={`/api/platform-changelog/v1/services/${name}/deploys`} />
+                        <DeployTable key={service.name} dataPath={`/api/v1/services/${name}/deploys`} />
                     </TabContent>
                 </>}
             </>     


### PR DESCRIPTION
## What?
Since the app is going to be accessible on devshift, we don't need this long app root. I'm not sure if we want to, but I've seen apps host their ui on domain.com/ui like vault does.

This also goes with the change removing the api from inside the apps route (which was needed with turnpike), so no more /app/platform-changelog/api/platform-changelog/v1/commits.

## Why?
URLs

## How?

## Testing

## Anything Else?

## Secure Coding Practices Checklist Link

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
