### PR TITLE
Explicitly set the oauth-proxy version number for the image tag

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -333,4 +333,4 @@ parameters:
 - name: OAUTH_PROXY_IMAGE_NAME
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_PROXY_IMAGE_TAG
-  value: "latest"
+  value: "4.10.0"


### PR DESCRIPTION
## What?
App-interface does not like the way we are setting the image tag to "latest".   Try explicitly setting the image tag to a version number.  I grabbed the same version number that gabi appears to be using.
