### PR TITLE
Service Account not being authenticated by oauth proxy

### DIFF
--- a/deployment/clusterrole.yml
+++ b/deployment/clusterrole.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: changelog-proxy-can-create-token-reviews
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: platform-changelog
+  namespace: change-log-dev

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -20,10 +20,6 @@ objects:
     name: tekton-pipeline
 # solution to service account auth from
 # https://github.com/openshift/oauth-proxy/issues/179#issuecomment-1202279241
-# I definitely don't like it
-# If I knew more about openshift, I would want it to work where 
-# we have a serviceaccount "group" that has post access and another with only get access
-# in the case that another service wants to hit changelog
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -34,7 +30,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
-    name: oauth-service-account-access
+    name: changelog-oauth-service-account-access
     namespace: default
   rules:
   - apiGroups:
@@ -43,6 +39,7 @@ objects:
     - configmaps
     verbs:
     - get
+    - update
     resourceNames:
     - oauth-service-account-access
 - apiVersion: apps/v1
@@ -308,13 +305,12 @@ objects:
           - --https-address=:8443
           - --provider=openshift
           - --openshift-service-account=platform-changelog
-          - --openshift-delegate-urls={"/api":{"group":"","resource":"configmaps","verb":"post","namespace":"default","name":"oauth-service-account-access"}}
+          - --openshift-delegate-urls={"/":{"group":"","resource":"configmaps","verb":"update","namespace":"default","name":"oauth-service-account-access"}}
           - --upstream=http://platform-changelog-ui:8080
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/proxy/secrets/platform-changelog-cookie
           - --request-logging=true
-          - --auth-logging=true
           volumeMounts:
           - mountPath: /etc/proxy/secrets
             name: platform-changelog-cookie

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -18,6 +18,33 @@ objects:
   kind: ServiceAccount
   metadata:
     name: tekton-pipeline
+# solution to service account auth from
+# https://github.com/openshift/oauth-proxy/issues/179#issuecomment-1202279241
+# I definitely don't like it
+# If I knew more about openshift, I would want it to work where 
+# we have a serviceaccount "group" that has post access and another with only get access
+# in the case that another service wants to hit changelog
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: oauth-service-account-access
+    namespace: default
+  data:
+    description: Fake ConfigMap to give all authenticated users access to a given service behind openshift-oauth-proxy.
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: oauth-service-account-access
+    namespace: default
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    resourceNames:
+    - oauth-service-account-access
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -281,11 +308,13 @@ objects:
           - --https-address=:8443
           - --provider=openshift
           - --openshift-service-account=platform-changelog
+          - --openshift-delegate-urls={"/api":{"group":"","resource":"configmaps","verb":"post","namespace":"default","name":"oauth-service-account-access"}}
           - --upstream=http://platform-changelog-ui:8080
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/proxy/secrets/platform-changelog-cookie
           - --request-logging=true
+          - --auth-logging=true
           volumeMounts:
           - mountPath: /etc/proxy/secrets
             name: platform-changelog-cookie

--- a/deployment/rolebinding.yml
+++ b/deployment/rolebinding.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: oauth-service-account-access
+  namespace: change-log-dev
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: oauth-service-account-access


### PR DESCRIPTION
## What?
Solution to service account auth from
https://github.com/openshift/oauth-proxy/issues/179#issuecomment-1202279241


I definitely don't like it.

If I knew more about openshift, I would want it to work where we have a serviceaccount "group" that has post access and another with only get access in the case another service wants to hit changelog.

## Why?
The proxy is blocking tekton tesk runs.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
