### PR TITLE
[BUG] Timeline fetching first set of data twice

### DIFF
--- a/src/components/Timelines.js
+++ b/src/components/Timelines.js
@@ -23,6 +23,7 @@ function Timelines({dataPath=`/api/v1/timelines`, includeRepo = false, ghURL="",
 
     useEffect(() => {
         fetchTimelines();
+        setOffset(offset + PER_CALL);
     }, []);
 
     const observer = useRef();
@@ -40,8 +41,7 @@ function Timelines({dataPath=`/api/v1/timelines`, includeRepo = false, ghURL="",
                 setOffset(offset + PER_CALL);
                 fetchTimelines();
             }
-        }
-        , { threshold: 0.5 });
+        }, { threshold: 0.5 });
 
         if (node) observer.current.observe(node);
     }, [loading]);


### PR DESCRIPTION
## What?
The timeline screen is displaying info twice
![twice](https://github.com/RedHatInsights/platform-changelog-ui/assets/87503474/126b61fe-6bdf-441a-b207-c290daa4a6e9)

## Why?
Offset wasn't updated after init call

## How?

## Testing

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
